### PR TITLE
Add bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,0 +1,56 @@
+---
+name: 🐛 Bug Report
+description: "File a bug report, if you've discovered a problem in The Starter Kit."
+labels: ["type/bug"]
+body:
+- type: input
+  id: "version"
+  attributes:
+    label: "Which version of The Starter Kit are you using? (Please write the *exact* version, example: 13.0.0)"
+    description: ""
+  validations:
+    required: true
+- type: input
+  id: "umbracoversion"
+  attributes:
+    label: "Which Umbraco version are you using? (Please write the *exact* version, example: 13.5.2)"
+    description: "Use the help icon in the Umbraco backoffice to find the version you're using"
+  validations:
+    required: true
+- type: textarea
+  id: "summary"
+  attributes:
+    label: "Bug summary"
+    description: "Write a short summary of the bug."
+    placeholder: "Try to pinpoint it as much as possible."
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: "Specifics"
+    id: "specifics"
+    description: "Remember that you can format code and logs nicely with the `<>` button"
+    placeholder: >
+      Mention the URL where this bug occurs, if applicable
+
+      Please mention if you've checked it in other browsers as well
+
+      Please include full error messages and screenshots, gifs or mp4 videos if applicable
+- type: textarea
+  attributes:
+    label: "Steps to reproduce"
+    id: "reproduction"
+    description: "How can we reproduce the problem on a clean Umbraco install?"
+    placeholder: >
+      Please include screenshots, gifs or mp4 videos if applicable
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: "Expected result / actual result"
+    id: "result"
+    description: "What did you expect that would happen and what is the actual result of the above steps?"
+    placeholder: >
+      Describe the intended/desired outcome after you did the steps mentioned.
+
+      Describe the behaviour of the bug

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
Adding a bug report template to the repository to make sure we have all the information we need to tackle issues.
It was inspired by the templates from other Umbraco repositories (CMS, Commerce, ...).

Not sure if there are useful links that we could add (like in the CMS issue template config).