### PR TITLE
Remove empty description field

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -7,7 +7,6 @@ body:
   id: "version"
   attributes:
     label: "Which version of The Starter Kit are you using? (Please write the *exact* version, example: 13.0.0)"
-    description: ""
   validations:
     required: true
 - type: input


### PR DESCRIPTION
The following error is being shown in the new issue template that was just created:
![image](https://github.com/user-attachments/assets/4b7cddaa-3b93-417b-b1f0-8d08be4b2722)
`description` is not a required property, as far as I can see, so I think the issue is that it simply does not allow empty string.

_Side note: Is there a way to validate github templates before merging?_