### PR TITLE
Remove old url from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,6 @@ You can find the Starter Kit on NuGet by running the following command:
 dotnet add package Umbraco.TheStarterKit --version 16.0.0-rc
 ```
 
-## Content
-
-Get in touch if you wish to have access to this Umbraco Cloud project, which contains the master content for the Starter Kit:
-https://umbraco-starter-kit.s1.umbraco.io
-
 ## Development
 
 If you are doing development for the Starter Kit, you can launch the [Umbraco.SampleSite.Web](examples/Umbraco.SampleSite.Web/) contained in this repo.


### PR DESCRIPTION
Fixes #85 

Removed the "Content" section from the README as it does not apply anymore:
- The url is not accessible anymore
- The content is committed in the repository